### PR TITLE
Fix overriding archetype component data in YAML

### DIFF
--- a/lmeditor/src/app/save_load.cpp
+++ b/lmeditor/src/app/save_load.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <lmeditor/model/selection.h>
 #include <lmng/pose.h>
-#include <lmng/serialisation.h>
+#include <lmng/yaml_save_load.h>
 #include <yaml-cpp/yaml.h>
 
 namespace lmeditor
@@ -23,7 +23,7 @@ bool editor_app::on_map_saved(const std::string &project_path)
 void editor_app::save_map(std::filesystem::path const &absolute_path)
 {
     auto yaml = YAML::Node{};
-    lmng::serialise(map, asset_cache, yaml);
+    lmng::save_registry_as_yaml(map, asset_cache, yaml);
 
     std::ofstream output{absolute_path};
     output << yaml;
@@ -44,7 +44,7 @@ void editor_app::load_map(const std::string &project_path)
     auto map_yaml =
       YAML::LoadFile((project_dir / (project_path + ".lmap")).string());
     map.clear();
-    lmng::deserialise(map_yaml, map, asset_cache);
+    lmng::populate_registry_from_yaml(map_yaml, map, asset_cache);
     map_file_project_relative_path = project_path;
 }
 

--- a/lmng/CMakeLists.txt
+++ b/lmng/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(
   SHARED
 
   src/reflect_component.cpp
-  src/serialisation.cpp
+  src/yaml_save_load.cpp
   src/bullet_physics/bullet_physics.cpp
   src/bullet_physics/rigid_body.cpp
   src/bullet_physics/character_controller.cpp
@@ -27,6 +27,7 @@ add_library(
   src/logging.cpp
   src/context.cpp
   src/any_component.cpp
+  src/archetype.cpp
 )
 
 target_include_directories(

--- a/lmng/include/lmng/archetype.h
+++ b/lmng/include/lmng/archetype.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "asset_cache.h"
+#include <entt/entt.hpp>
 #include <filesystem>
 #include <string>
 #include <yaml-cpp/yaml.h>
@@ -16,6 +17,12 @@ struct archetype
 {
     std::string asset_path;
 };
+
+void load_archetype_data(
+  const entt::entity &entity,
+  entt::registry &registry,
+  std::string const &asset_path,
+  asset_cache &asset_cache);
 
 class yaml_archetype_loader : public asset_loader_interface<archetype_data>
 {
@@ -37,7 +44,8 @@ class yaml_archetype_loader : public asset_loader_interface<archetype_data>
 };
 } // namespace lmng
 
-inline std::ostream &operator<<(std::ostream &os, lmng::archetype const &archetype)
+inline std::ostream &
+  operator<<(std::ostream &os, lmng::archetype const &archetype)
 {
     os << archetype.asset_path;
     return os;

--- a/lmng/include/lmng/meta/any_component.h
+++ b/lmng/include/lmng/meta/any_component.h
@@ -30,6 +30,11 @@ void replace_on_entity(
   entt::registry &registry,
   entt::entity entity);
 
+void assign_or_replace_on_entity(
+  entt::meta_any const &component,
+  entt::registry &registry,
+  entt::entity entity);
+
 void remove_from_entity(
   entt::meta_type const &component_type,
   entt::registry &registry,

--- a/lmng/include/lmng/meta/reflect_component.h
+++ b/lmng/include/lmng/meta/reflect_component.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "any_component.h"
 #include "../hierarchy.h"
 #include "../name.h"
+#include "any_component.h"
 #include <Eigen/Eigen>
 #include <entt/entt.hpp>
 #include <fmt/ostream.h>
@@ -27,6 +27,16 @@ void replace_on_entity(
   entt::entity entity)
 {
     registry->replace<component_type>(
+      entity, *static_cast<component_type const *>(component));
+}
+
+template <typename component_type>
+void assign_or_replace_on_entity(
+  void const *component,
+  entt::registry *registry,
+  entt::entity entity)
+{
+    registry->assign_or_replace<component_type>(
       entity, *static_cast<component_type const *>(component));
 }
 
@@ -227,6 +237,8 @@ void connect_logging(entt::registry &registry)
       .ctor<&lmng::construct<_type>>()                                         \
       .func<&lmng::assign_to_entity<_type>>("assign_to_entity"_hs)             \
       .func<&lmng::replace_on_entity<_type>>("replace_on_entity"_hs)           \
+      .func<&lmng::assign_or_replace_on_entity<_type>>(                        \
+        "assign_or_replace_on_entity"_hs)                                      \
       .func<&lmng::get_from_entity<_type>>("get_from_entity"_hs)               \
       .func<&lmng::remove_from_entity<_type>>("remove_from_entity"_hs)         \
       .func<&lmng::clone<_type>>("clone"_hs)                                   \

--- a/lmng/include/lmng/yaml_save_load.h
+++ b/lmng/include/lmng/yaml_save_load.h
@@ -6,28 +6,40 @@
 
 namespace lmng
 {
-YAML::Node serialise_component(
+YAML::Node save_component_as_yaml(
   entt::registry const &registry,
   entt::meta_any const &component);
 
-entt::meta_any deserialise_component(
+entt::meta_any construct_component_from_yaml(
   const entt::registry &registry,
   const YAML::Node &component_name_yaml,
   YAML::Node const &component_yaml);
 
-entt::meta_any deserialise_component(
+entt::meta_any construct_component_from_yaml(
   const entt::registry &registry,
   std::string const &component_type_name,
   YAML::Node const &component_yaml);
 
-void serialise(
+void assign_components_from_yaml(
+  entt::registry &registry,
+  entt::entity into_entity,
+  YAML::Node const &components_yaml);
+
+void create_children_from_yaml(
+  entt::registry &registry,
+  const YAML::Node &yaml,
+  asset_cache &asset_cache,
+  const entt::entity &entity);
+
+void save_registry_as_yaml(
   entt::registry &registry,
   asset_cache &asset_cache,
   YAML::Node &yaml);
-void deserialise(
+void populate_registry_from_yaml(
   YAML::Node const &yaml,
   entt::registry &registry,
   asset_cache &asset_cache);
 
-entt::registry deserialise(YAML::Node const &yaml, asset_cache &asset_cache);
+entt::registry
+  create_registry_from_yaml(YAML::Node const &yaml, asset_cache &asset_cache);
 } // namespace lmng

--- a/lmng/src/animation.cpp
+++ b/lmng/src/animation.cpp
@@ -4,8 +4,8 @@
 #include <lmng/animation.h>
 #include <lmng/hierarchy.h>
 #include <lmng/name.h>
-#include <lmng/serialisation.h>
 #include <lmng/transform.h>
+#include <lmng/yaml_save_load.h>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/zip.hpp>
 #include <yaml-cpp/yaml.h>

--- a/lmng/src/any_component.cpp
+++ b/lmng/src/any_component.cpp
@@ -43,6 +43,16 @@ void replace_on_entity(
       .invoke({}, component.data(), &registry, entity);
 }
 
+void assign_or_replace_on_entity(
+  const entt::meta_any &component,
+  entt::registry &registry,
+  entt::entity entity)
+{
+    component.type()
+      .func("assign_or_replace_on_entity"_hs)
+      .invoke({}, component.data(), &registry, entity);
+}
+
 void remove_from_entity(
   entt::meta_type const &component_type,
   entt::registry &registry,

--- a/lmng/src/archetype.cpp
+++ b/lmng/src/archetype.cpp
@@ -1,0 +1,22 @@
+#include <entt/entt.hpp>
+#include <lmng/archetype.h>
+#include <lmng/yaml_save_load.h>
+#include <yaml-cpp/yaml.h>
+
+namespace lmng
+{
+void load_archetype_data(
+  const entt::entity &entity,
+  entt::registry &registry,
+  std::string const &asset_path,
+  asset_cache &asset_cache)
+{
+    auto archetype_data = asset_cache.load<lmng::archetype_data>(asset_path);
+
+    assign_components_from_yaml(
+      registry, entity, archetype_data->yaml["components"]);
+
+    create_children_from_yaml(
+      registry, archetype_data->yaml["children"], asset_cache, entity);
+}
+} // namespace lmng

--- a/lmng/src/pose.cpp
+++ b/lmng/src/pose.cpp
@@ -4,8 +4,8 @@
 #include <lmng/hierarchy.h>
 #include <lmng/name.h>
 #include <lmng/pose.h>
-#include <lmng/serialisation.h>
 #include <lmng/transform.h>
+#include <lmng/yaml_save_load.h>
 #include <yaml-cpp/yaml.h>
 
 static YAML::Node
@@ -13,8 +13,8 @@ static YAML::Node
 {
     YAML::Node yaml_node;
 
-    yaml_node["Transform"] =
-      lmng::serialise_component(registry, registry.get<lmng::transform>(child));
+    yaml_node["Transform"] = lmng::save_component_as_yaml(
+      registry, registry.get<lmng::transform>(child));
     yaml_node["Children"] = lmng::save_pose(registry, child);
 
     return std::move(yaml_node);
@@ -33,7 +33,7 @@ void load_pose(
 
         registry.replace<transform>(
           child,
-          deserialise_component(
+          construct_component_from_yaml(
             registry, "Transform", yaml_entity.second["Transform"])
             .cast<transform>());
 

--- a/lmng/src/serialisation.cpp
+++ b/lmng/src/serialisation.cpp
@@ -275,49 +275,11 @@ void deserialise_entity(
     deserialise_children(registry, yaml["children"], asset_cache, entity);
 }
 
-void deserialise_v0(YAML::Node const &yaml, entt::registry &registry)
-{
-    std::unordered_map<std::string, entt::entity> name_map;
-
-    for (auto const &actor_yaml : yaml)
-    {
-        auto new_entity = registry.create();
-
-        auto name = actor_yaml.first.as<std::string>();
-
-        registry.assign<lmng::name>(new_entity, name);
-
-        name_map.emplace(name, new_entity);
-    }
-
-    for (auto const &actor_yaml : yaml)
-    {
-        auto new_entity = name_map[actor_yaml.first.as<std::string>()];
-
-        for (auto const &component_yaml : actor_yaml.second)
-        {
-            lmng::assign_to_entity(
-              deserialise_component(
-                registry, component_yaml.first, component_yaml.second),
-              registry,
-              new_entity);
-        }
-    }
-}
-
 void deserialise(
   YAML::Node const &yaml,
   entt::registry &registry,
   asset_cache &asset_cache)
 {
-    auto version_node = yaml["schema_version"];
-
-    if (!version_node.IsDefined())
-    {
-        deserialise_v0(yaml, registry);
-        return;
-    }
-
     for (auto const &entity_yaml : yaml["entities"])
     {
         deserialise_entity(

--- a/lmng/test/test_archetype.cpp
+++ b/lmng/test/test_archetype.cpp
@@ -7,8 +7,8 @@
 #include <lmng/hierarchy.h>
 #include <lmng/logging.h>
 #include <lmng/name.h>
-#include <lmng/serialisation.h>
 #include <lmng/transform.h>
+#include <lmng/yaml_save_load.h>
 
 lmng::archetype_data create_test_archetype()
 {
@@ -71,7 +71,7 @@ TEST_CASE("Map serialisation with archetypes")
     expected_yaml["Parent"] = expected_parent_yaml;
 
     YAML::Node actual_yaml;
-    lmng::serialise(registry, asset_cache, actual_yaml);
+    lmng::save_registry_as_yaml(registry, asset_cache, actual_yaml);
 
     std::ostringstream expected_str{}, actual_str{};
     expected_str << expected_yaml;
@@ -109,7 +109,7 @@ TEST_CASE("Map deserialisation with archetypes")
     lmng::hierarchy_system hierarchy_system{registry};
     lmng::connect_component_logging(registry);
 
-    lmng::deserialise(map_yaml, registry, asset_cache);
+    lmng::populate_registry_from_yaml(map_yaml, registry, asset_cache);
 
     auto parent = lmng::find_entity(registry, "Parent");
 

--- a/lmng/test/test_archetype.cpp
+++ b/lmng/test/test_archetype.cpp
@@ -91,7 +91,15 @@ TEST_CASE("Map deserialisation with archetypes")
 
     YAML::Node parent_yaml;
     parent_yaml["archetype"] = "archetype";
-    parent_yaml["components"] = YAML::Node{};
+
+    YAML::Node parent_transform_yaml;
+
+    parent_transform_yaml["Position"] = "4.0 5.0 6.0";
+
+    YAML::Node parent_components_yaml;
+    parent_components_yaml["Transform"] = parent_transform_yaml;
+
+    parent_yaml["components"] = parent_components_yaml;
     parent_yaml["children"] = YAML::Node{};
 
     map_yaml["entities"]["Parent"] = parent_yaml;
@@ -113,5 +121,5 @@ TEST_CASE("Map deserialisation with archetypes")
 
     auto parent_transform = registry.get<lmng::transform>(parent);
 
-    REQUIRE(parent_transform.position == Eigen::Vector3f{1.f, 2.f, 3.f});
+    REQUIRE(parent_transform.position == Eigen::Vector3f{4.f, 5.f, 6.f});
 }

--- a/lmng/test/test_pose.cpp
+++ b/lmng/test/test_pose.cpp
@@ -5,8 +5,8 @@
 #include <lmng/meta/any_component.h>
 #include <lmng/name.h>
 #include <lmng/pose.h>
-#include <lmng/serialisation.h>
 #include <lmng/transform.h>
+#include <lmng/yaml_save_load.h>
 #include <range/v3/algorithm/generate.hpp>
 #include <range/v3/view/zip.hpp>
 

--- a/sample/src/application.cpp
+++ b/sample/src/application.cpp
@@ -3,7 +3,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <lmlib/camera.h>
-#include <lmng/serialisation.h>
+#include <lmng/yaml_save_load.h>
 
 sample_app::sample_app()
     : resources{},
@@ -13,7 +13,7 @@ sample_app::sample_app()
         [&](auto frame) { return on_new_frame(frame); },
         [&]() { on_quit(); },
       },
-      registry{lmng::deserialise(
+      registry{lmng::create_registry_from_yaml(
         YAML::LoadFile("../sample/character_movement.lmap"),
         asset_cache)},
       simulation{lmng::simulation_init{registry, asset_cache}},


### PR DESCRIPTION
Use assign_or_replace on the deserialised entity with its component YAML data since the components could have been assigned already from the archetype data.